### PR TITLE
Conditional generator expression for target_link_libraries to handle mac computers

### DIFF
--- a/camerad/archon.cpp
+++ b/camerad/archon.cpp
@@ -79,10 +79,6 @@ namespace Archon {
     this->frame.buffetimestamp.resize( Archon::nbufs );
   }
 
-  // Archon::Interface deconstructor
-  //
-  Interface::~Interface() = default;
-
 
   /**************** Archon::Interface::interface ******************************/
   long Interface::interface(std::string &iface) {

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(utilities STATIC
 add_library(logentry STATIC
         ${PROJECT_UTILS_DIR}/logentry.cpp
         )
-target_link_libraries( logentry stdc++fs )
+target_link_libraries( logentry $<IF:$<PLATFORM_ID:Darwin>,,stdc++fs> )
 
 add_library(network STATIC
         ${PROJECT_UTILS_DIR}/network.cpp


### PR DESCRIPTION
Updated utils/CMakeLists.txt with a conditional generator expression that will not add the stdc++fs library to the link command when on a mac computer, but will add it when on any other platform.