### PR TITLE
Display exptime value with proper units in longexposure function

### DIFF
--- a/camerad/archon.cpp
+++ b/camerad/archon.cpp
@@ -6050,7 +6050,8 @@ namespace Archon {
     //
     this->camera_info.exposure_unit   = ( this->is_longexposure ? "sec" : "msec" );
     this->camera_info.exposure_factor = ( this->is_longexposure ? 1 : 1000 );
-    state_out = ( this->is_longexposure ? "true" : "false" );
+    message.str(""); message << this->camera_info.exposure_time << ( this->is_longexposure ? " sec" : " msec" );
+    state_out = ( this->is_longexposure ? "true, exptime = " : "false, exptime = " ) + message.str();
 
     // if no error then set the parameter on the Archon
     //

--- a/camerad/archon.cpp
+++ b/camerad/archon.cpp
@@ -6052,6 +6052,7 @@ namespace Archon {
     this->camera_info.exposure_factor = ( this->is_longexposure ? 1 : 1000 );
     message.str(""); message << this->camera_info.exposure_time << ( this->is_longexposure ? " sec" : " msec" );
     state_out = ( this->is_longexposure ? "true, exptime = " : "false, exptime = " ) + message.str();
+    logwrite(state_out);
 
     // if no error then set the parameter on the Archon
     //

--- a/camerad/archon.cpp
+++ b/camerad/archon.cpp
@@ -6052,7 +6052,7 @@ namespace Archon {
     this->camera_info.exposure_factor = ( this->is_longexposure ? 1 : 1000 );
     message.str(""); message << this->camera_info.exposure_time << ( this->is_longexposure ? " sec" : " msec" );
     state_out = ( this->is_longexposure ? "true, exptime = " : "false, exptime = " ) + message.str();
-    logwrite(state_out);
+    logwrite(function, state_out);
 
     // if no error then set the parameter on the Archon
     //


### PR DESCRIPTION
To notify the user that the exptime value may not be what is expected, the longexposure command now prints out the new exposure time and units.

This avoids the scaling issue when going from msec to sec and partially addresses issue #19.