### PR TITLE
Dweather/conan build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,17 +2,34 @@
 # CMakeLists.txt
 # top-level CMake input file
 # ----------------------------------------------------------------------------
+cmake_minimum_required(VERSION 3.12)
+project(camera C CXX)
+
 
 # ----------------------------------------------------------------------------
 # user must define the interface type here
 # valid types are: "AstroCam" | "Archon"
 # ----------------------------------------------------------------------------
+set(INTERFACE_TYPE "Archon" CACHE STRING "Type of instrument interface to build for")
+set_property(CACHE INTERFACE_TYPE PROPERTY STRINGS Archon AstroCam)
+
+#for some reason all libraries are built static by default
+#I'm not sure if this is for technical reasons or just preferred
+#Anyway, give the option but set it to static by default 
+option(BUILD_SHARED_LIBS "build shared libraries instead of static" OFF)
 
 
-# Interface type can be set via command line ( Archon | AstroCam )
-IF (NOT DEFINED INTERFACE_TYPE)
-    set(INTERFACE_TYPE "Archon")
-endif ()
+#the build system of camerad previously outputted binaries to the source folder
+# leave this by default for compatibility but allow an option to put the binaries in the usual place
+# (the build folder)
+option(OUTPUT_TO_SRC_DIR "output binaries and libraries to source folder rather than build folder" ON)
+
+
+
+if(NOT CMAKE_BUILD_TYPE)
+  message(STATUS "no build type specified defaulting to RelWithDebInfo")
+  set(CMAKE_BUILD_TYPE RelWithDebInfo)
+endif()
 
 # Instrument can be set via command line generic is the default value
 IF (NOT DEFINED INSTR)
@@ -28,30 +45,19 @@ endif ()
 # un-comment the following to log verbose debug messages
 #add_definitions(-DLOGLEVEL_DEBUG)
 
-cmake_minimum_required(VERSION 3.12)
+#setting these standard variables will (since CMake 3.1)
+#setup the proper -std=c++17 etc flags, no need to do it manually
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_CXX_EXTENSIONS OFF)
 
-find_program(GXX_COMPILER NAMES g++)
 
-if(GXX_COMPILER)
-    message(STATUS "Found g++: ${GXX_COMPILER}")
-    set(CMAKE_CXX_COMPILER ${GXX_COMPILER})
-else()
-    message(FATAL_ERROR "g++ compiler not found. Please install g++ and try again.")
+if(OUTPUT_TO_SRC_DIR)
+  #this is the "legacy" behaviour
+  #if this option is not set, binaries will output in their default place in the CMake build output folder
+  set(EXECUTABLE_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/bin)
+  set(LIBRARY_OUTPUT_PATH ${CMAKE_SOURCE_DIR}/lib)
 endif()
-
-project(camera)
-
-set(CMAKE_GXX_STANDARD 17)
-set(CMAKE_GXX_STANDARD_REQUIRED ON)
-set(CMAKE_GXX_EXTENSIONS OFF)
-
-# Run "cmake .." from the project's build/ directory!
-#
-set(PROJECT_BASE_DIR $ENV{PWD}/../)
-
-set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BASE_DIR}/bin)
-set(LIBRARY_OUTPUT_PATH ${PROJECT_BASE_DIR}/lib)
-
 
 if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
     include_directories(/usr/local/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # CMakeLists.txt
 # top-level CMake input file
 # ----------------------------------------------------------------------------
-cmake_minimum_required(VERSION 3.12)
+cmake_minimum_required(VERSION 3.15)
 project(camera C CXX)
 
 
@@ -23,6 +23,7 @@ option(BUILD_SHARED_LIBS "build shared libraries instead of static" OFF)
 # leave this by default for compatibility but allow an option to put the binaries in the usual place
 # (the build folder)
 option(OUTPUT_TO_SRC_DIR "output binaries and libraries to source folder rather than build folder" ON)
+
 
 
 
@@ -64,6 +65,31 @@ if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
 endif()
 
 find_package(Threads)
+
+
+#both emulator and camerad actually depend on cfitsio and CCfits (one only by header)
+#so we need to do those finds here, not in camerad/CMakeLists.
+
+#NOTE (by danw): strictly, the archon interface requires linking to cfitsio because
+#CCfits is included by archon.h. I'm not sure this is intentional.
+#Anyway, to reflect that I moved the public linkage of these packages down to the interface
+#target rather than camerad.
+
+#cfitsio has provided a cmake config file for quite a long time
+#on some systems where include files are not in the default place, this will still find them
+#if it fails, we fall back to camerad previous behaviour, manually finding the library file ONLY
+#(and not bothering about includes if they're not in the right place)
+
+
+#for cfitsio and CCfits  we now provide our own find module
+#this allows for systems with non-standard paths to
+#replace that find module without hacking our build system (e.g. fedora, suse, etc)
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+find_package(cfitsio REQUIRED)
+find_package(CCfits REQUIRED)
+
+
 
 #no need for absolute paths here, they are by default relative to ${CMAKE_CURRENT_LIST_DIR}
 add_subdirectory(utils)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,8 +59,9 @@ endif()
 
 find_package(Threads)
 
-add_subdirectory(${PROJECT_BASE_DIR}/utils)
-add_subdirectory(${PROJECT_BASE_DIR}/common)
-add_subdirectory(${PROJECT_BASE_DIR}/camerad)
-add_subdirectory(${PROJECT_BASE_DIR}/emulator)
-add_subdirectory(${PROJECT_BASE_DIR}/tests EXCLUDE_FROM_ALL)
+#no need for absolute paths here, they are by default relative to ${CMAKE_CURRENT_LIST_DIR}
+add_subdirectory(utils)
+add_subdirectory(common)
+add_subdirectory(camerad)
+add_subdirectory(emulator)
+add_subdirectory(tests EXCLUDE_FROM_ALL)

--- a/camerad/CMakeLists.txt
+++ b/camerad/CMakeLists.txt
@@ -7,6 +7,7 @@ cmake_minimum_required(VERSION 3.12)
 include_directories(${CMAKE_SOURCE_DIR}/utils)
 include_directories(${CMAKE_SOURCE_DIR}/common)
 
+
 # ----------------------------------------------------------------------------
 # Setup for appropriate hardware interface...
 #
@@ -16,6 +17,8 @@ include_directories(${CMAKE_SOURCE_DIR}/common)
 #   INTERFACE_INCLUDES  list of include paths for target interface
 #   interface           target for interfacing to appropriate hardware
 # ----------------------------------------------------------------------------
+
+
 
 # ----------------------------------------------------------------------------
 # AstroCam ARC-64/66 PCI/e interfaces
@@ -55,21 +58,18 @@ if (${INTERFACE_TYPE} STREQUAL "AstroCam")
     find_library(CARC_DEVICE "CArcDevice3.6" NAMES "libCArcDevice3.6.so" PATHS ${ARCAPI_DIR}/Release)
     find_library(CARC_FITS "CArcFitsFile3.6" NAMES "libCArcFitsFile3.6.so" PATHS ${ARCAPI_DIR}/Release)
 
+    add_library(interface STATIC ${INTERFACE_SOURCE})
+
+    
     # ----------------------------------------------------------------------------
     # STA Archon interfaces
     # ----------------------------------------------------------------------------
 
 elseif (${INTERFACE_TYPE} STREQUAL "Archon")
     message(STATUS "compiling for STA Archon")
-    set(INTERFACE_TARGET archon)
     add_definitions(-Wall -ansi -O1 -Wno-variadic-macros -std=c++17 -ggdb)
     add_definitions(-DSTA_ARCHON)
-    list(APPEND INTERFACE_SOURCE
-            "archon.cpp"
-    )
-    list(APPEND INTERFACE_INCLUDES
-            "${ARCHON_INCLUDE}"
-    )
+    list(APPEND INTERFACE_SOURCE "archon.cpp")
     add_library(interface STATIC "${INTERFACE_SOURCE}")
     if (${DETECTOR_TYPE} STREQUAL "Hxrg")
         message(STATUS "compiling for HXRG detector")
@@ -112,38 +112,15 @@ endif ()
 
 # Now add the defined interface target:
 #
-add_library(${INTERFACE_TARGET} ${INTERFACE_SOURCE})
-target_include_directories(${INTERFACE_TARGET} PUBLIC ${INTERFACE_INCLUDES})
+target_link_libraries(interface PUBLIC cfitsio CCfits)
 
 
+
+#Note from danw: I'm afraid camera.h technically includes CCfits, and so a public
+#dependency on those is needed
 add_library(camera camera.cpp)
+target_link_libraries(camera PUBLIC cfitsio CCfits)
 
-# ----------------------------------------------------------------------------
-# External libraries, such as FITS, etc.
-# ----------------------------------------------------------------------------
-
-#cfitsio has provided a cmake config file for quite a long time
-#on some systems where include files are not in the default place, this will still find them
-#if it fails, we fall back to camerad previous behaviour, manually finding the library file ONLY
-#(and not bothering about includes if they're not in the right place)
-find_package(cfitsio)
-
-#the package file defines a cmake target rather than just the variables
-#that target will also have correct path to include files
-if(NOT TARGET cfitsio)
-  message(STATUS "cfitsio package file not found, maybe an old old system. Try finding library manually")
-  find_library(CFITS_LIB cfitsio NAMES libcfitsio PATHS /usr/local/lib)
-  add_library(cfitsio UNKNOWN IMPORTED)
-  set_target_properties(cfitsio PROPERTIES IMPORTED_LOCATION ${CFITS_LIB})
-endif()
-
-#for CCfits, we now provide our own find module
-#this allows for systems with non-standard paths to
-#replace that find module without hacking our build system (e.g. fedora, suse, etc)
-
-
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
-find_package(CCfits REQUIRED)
 
 find_package(Threads)
 add_executable(camerad camerad.cpp  ${INTERFACE_INCLUDES})
@@ -158,15 +135,14 @@ target_link_libraries(camerad
         logentry
         common
         utilities
-        ${INTERFACE_TARGET}
+	interface
         ${CMAKE_THREAD_LIBS_INIT}
 	cfitsio
 	CCfits
 )
 
-target_link_libraries(camerad ${CARC_BASE})
-target_link_libraries(camerad ${CARC_DEVICE})
-target_link_libraries(camerad ${CARC_FITS})
+target_link_libraries(camerad ${CARC_BASE} ${CARC_DEVICE} ${CARC_FITS})
+
 
 # ----------------------------------------------------------------------------
 # cURL is not used here, so it's not strictly required, but cfitsio can

--- a/camerad/CMakeLists.txt
+++ b/camerad/CMakeLists.txt
@@ -4,11 +4,8 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-set(CAMERA_DIR ${PROJECT_BASE_DIR}/camerad)
-
 include_directories(${CMAKE_SOURCE_DIR}/utils)
 include_directories(${CMAKE_SOURCE_DIR}/common)
-link_directories(${PROJECT_BASE_DIR}/lib)
 
 # ----------------------------------------------------------------------------
 # Setup for appropriate hardware interface...
@@ -119,27 +116,37 @@ add_library(${INTERFACE_TARGET} ${INTERFACE_SOURCE})
 target_include_directories(${INTERFACE_TARGET} PUBLIC ${INTERFACE_INCLUDES})
 
 
-add_library(camera STATIC
-        camera.cpp
-)
+add_library(camera camera.cpp)
 
 # ----------------------------------------------------------------------------
 # External libraries, such as FITS, etc.
 # ----------------------------------------------------------------------------
 
-find_library(CCFITS_LIB CCfits NAMES libCCfits PATHS /usr/local/lib)
-find_library(CFITS_LIB cfitsio NAMES libcfitsio PATHS /usr/local/lib)
+#cfitsio has provided a cmake config file for quite a long time
+#on some systems where include files are not in the default place, this will still find them
+#if it fails, we fall back to camerad previous behaviour, manually finding the library file ONLY
+#(and not bothering about includes if they're not in the right place)
+find_package(cfitsio)
 
-message("CCFITS library: ${CCFITS_LIB}")
+#the package file defines a cmake target rather than just the variables
+#that target will also have correct path to include files
+if(NOT TARGET cfitsio)
+  message(STATUS "cfitsio package file not found, maybe an old old system. Try finding library manually")
+  find_library(CFITS_LIB cfitsio NAMES libcfitsio PATHS /usr/local/lib)
+  add_library(cfitsio IMPORTED)
+  set_target_properties(cfitsio IMPORTED_LOCATION ${CFITS_LIB})
+endif()
 
+#for CCfits, we now provide our own find module
+#this allows for systems with non-standard paths to
+#replace that find module without hacking our build system (e.g. fedora, suse, etc)
+
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
+find_package(CCfits REQUIRED)
 
 find_package(Threads)
-
-
-add_executable(camerad
-        camerad.cpp
-        ${INTERFACE_INCLUDES}
-)
+add_executable(camerad camerad.cpp  ${INTERFACE_INCLUDES})
 
 # ----------------------------------------------------------------------------
 # Everyone gets this:
@@ -153,8 +160,8 @@ target_link_libraries(camerad
         utilities
         ${INTERFACE_TARGET}
         ${CMAKE_THREAD_LIBS_INIT}
-        ${CCFITS_LIB}
-        ${CFITS_LIB}
+	cfitsio
+	CCfits
 )
 
 target_link_libraries(camerad ${CARC_BASE})
@@ -167,7 +174,7 @@ target_link_libraries(camerad ${CARC_FITS})
 # If it's installed on the system then link it, but don't make it mandatory.
 # ----------------------------------------------------------------------------
 #
-include(FindCURL)
+find_package(CURL)
 
 if (CURL_FOUND STREQUAL "FALSE")
     message(STATUS "cURL was not found but may be needed by some systems if built into cfitsio.\n   If you experience undefined curl references during linking \n   then please your cURL installation.")

--- a/camerad/CMakeLists.txt
+++ b/camerad/CMakeLists.txt
@@ -133,7 +133,7 @@ find_package(cfitsio)
 if(NOT TARGET cfitsio)
   message(STATUS "cfitsio package file not found, maybe an old old system. Try finding library manually")
   find_library(CFITS_LIB cfitsio NAMES libcfitsio PATHS /usr/local/lib)
-  add_library(cfitsio IMPORTED)
+  add_library(cfitsio UNKNOWN IMPORTED)
   set_target_properties(cfitsio IMPORTED_LOCATION ${CFITS_LIB})
 endif()
 

--- a/camerad/CMakeLists.txt
+++ b/camerad/CMakeLists.txt
@@ -134,7 +134,7 @@ if(NOT TARGET cfitsio)
   message(STATUS "cfitsio package file not found, maybe an old old system. Try finding library manually")
   find_library(CFITS_LIB cfitsio NAMES libcfitsio PATHS /usr/local/lib)
   add_library(cfitsio UNKNOWN IMPORTED)
-  set_target_properties(cfitsio IMPORTED_LOCATION ${CFITS_LIB})
+  set_target_properties(cfitsio PROPERTIES IMPORTED_LOCATION ${CFITS_LIB})
 endif()
 
 #for CCfits, we now provide our own find module

--- a/camerad/CMakeLists.txt
+++ b/camerad/CMakeLists.txt
@@ -6,8 +6,8 @@ cmake_minimum_required(VERSION 3.12)
 
 set(CAMERA_DIR ${PROJECT_BASE_DIR}/camerad)
 
-include_directories(${PROJECT_BASE_DIR}/utils)
-include_directories(${PROJECT_BASE_DIR}/common)
+include_directories(${CMAKE_SOURCE_DIR}/utils)
+include_directories(${CMAKE_SOURCE_DIR}/common)
 link_directories(${PROJECT_BASE_DIR}/lib)
 
 # ----------------------------------------------------------------------------
@@ -68,7 +68,7 @@ elseif (${INTERFACE_TYPE} STREQUAL "Archon")
     add_definitions(-Wall -ansi -O1 -Wno-variadic-macros -std=c++17 -ggdb)
     add_definitions(-DSTA_ARCHON)
     list(APPEND INTERFACE_SOURCE
-            "${CAMERA_DIR}/archon.cpp"
+            "archon.cpp"
     )
     list(APPEND INTERFACE_INCLUDES
             "${ARCHON_INCLUDE}"
@@ -95,17 +95,17 @@ if (NOT DEFINED INSTR)
 else ()
     if (${INSTR} STREQUAL "nirc2")
         message(STATUS "building for nirc2 instrument")
-        list(APPEND INTERFACE_SOURCE "${CAMERA_DIR}/nirc2.cpp")
+        list(APPEND INTERFACE_SOURCE "nirc2.cpp")
     elseif (${INSTR} STREQUAL "generic")
         message(STATUS "building for generic instrument")
-        list(APPEND INTERFACE_SOURCE "${CAMERA_DIR}/generic.cpp")
+        list(APPEND INTERFACE_SOURCE "generic.cpp")
     elseif (${INSTR} STREQUAL "undefined")
         message(STATUS "no INSTR defined. using generic but other options are:")
         message(STATUS "cmake -DINSTR=nirc2,generic ..")
-        list(APPEND INTERFACE_SOURCE "${CAMERA_DIR}/generic.cpp")
+        list(APPEND INTERFACE_SOURCE "generic.cpp")
     else ()
         message(STATUS "unknown instrument " ${INSTR} ": using generic")
-        list(APPEND INTERFACE_SOURCE "${CAMERA_DIR}/generic.cpp")
+        list(APPEND INTERFACE_SOURCE "generic.cpp")
     endif ()
 endif ()
 
@@ -120,7 +120,7 @@ target_include_directories(${INTERFACE_TARGET} PUBLIC ${INTERFACE_INCLUDES})
 
 
 add_library(camera STATIC
-        ${CAMERA_DIR}/camera.cpp
+        camera.cpp
 )
 
 # ----------------------------------------------------------------------------
@@ -130,10 +130,14 @@ add_library(camera STATIC
 find_library(CCFITS_LIB CCfits NAMES libCCfits PATHS /usr/local/lib)
 find_library(CFITS_LIB cfitsio NAMES libcfitsio PATHS /usr/local/lib)
 
+message("CCFITS library: ${CCFITS_LIB}")
+
+
 find_package(Threads)
 
+
 add_executable(camerad
-        ${CAMERA_DIR}/camerad.cpp
+        camerad.cpp
         ${INTERFACE_INCLUDES}
 )
 

--- a/camerad/archon.cpp
+++ b/camerad/archon.cpp
@@ -104,6 +104,17 @@ namespace Archon {
   }
   /**************** Archon::Interface::interface ******************************/
 
+
+  /***Note from danw: I couldn't get this to link without adding a dummy method here no idea why
+   **/
+
+  long Interface::power(std::string state_in, std::string& retstring)
+   {
+     return do_power(state_in, retstring);
+   }
+
+  
+  
   /***** Archon::Interface::do_power ******************************************/
   /**
    * @brief      set/get the power state
@@ -876,7 +887,7 @@ namespace Archon {
    *
    */
   long Interface::archon_cmd(std::string cmd) { // use this form when the calling
-    std::string reply;                          // function doesn't need to look at the reply
+   std::string reply;                          // function doesn't need to look at the reply
     return( archon_cmd(cmd, reply) );
   }
   long Interface::archon_cmd(std::string cmd, std::string &reply) {

--- a/cmake/FindCCfits.cmake
+++ b/cmake/FindCCfits.cmake
@@ -11,17 +11,27 @@ if(PKG_CONFIG_FOUND)
 
   #for compatibility with camera-interface build system, alias the target to CCFITS_LIB as well  
   add_library(CCfits ALIAS PkgConfig::CCFITS)
+  set(CCfits_FOUND TRUE)
+  
 else()
   message(VERBOSE "no pkg-config, trying to locate CCfits manually")
   find_library(CCFITS_LIB CCfits NAMES libCCfits PATHS /usr/local/lib)
   message(VERBOSE "CCFITS library: ${CCFITS_LIB}")
+
+  find_path(CCFITS_INCLUDE CCfits.h PATHS /usr/local/lib)
+  message(VERBOSE "CCFITS include: ${CCFITS_INCLUDE}")
+
+  get_filename_component(CCFITS_INCLUDE_DIR ${CCFITS_INCLUDE} DIRECTORY)
   
   #note that we don't even bother to find non-standard include paths.
   #neither did the previous camera-interface build system.
   #If you have a non-standard include path, your CCfits installation should
   #have included a pkg-config file and mentioned it, or you should have dropped in your
   #own find module here. Good luck.
-  add_library(CCfits UNKNOWN IMPORTED)
+  add_library(CCfits UNKNOWNN IMPORTED)
   set_target_properties(CCfits PROPERTIES IMPORTED_LOCATION ${CCFITS_LIB})
+  set_target_properties(CCfits PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${CCFITS_INCLUDE_DIR})
+
+  set(CCfits_FOUND TRUE)
   
 endif()

--- a/cmake/FindCCfits.cmake
+++ b/cmake/FindCCfits.cmake
@@ -1,0 +1,27 @@
+#CCfits does by default provide a pkg-config recipe. Try this first, it's likely the best
+#however may not work on mac or windows
+
+
+#note that using the IMPORTED_TARGET argument below requires at least cmake 3.7
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  message(VERBOSE "found pkg-config, trying to locate CCfits using it")
+  pkg_check_modules(CCFITS CCfits REQUIRED IMPORTED_TARGET)
+
+  #for compatibility with camera-interface build system, alias the target to CCFITS_LIB as well  
+  add_library(CCfits ALIAS PkgConfig::CCFITS)
+else()
+  message(VERBOSE "no pkg-config, trying to locate CCfits manually")
+  find_library(CCFITS_LIB CCfits NAMES libCCfits PATHS /usr/local/lib)
+  message(VERBOSE "CCFITS library: ${CCFITS_LIB}")
+  
+  #note that we don't even bother to find non-standard include paths.
+  #neither did the previous camera-interface build system.
+  #If you have a non-standard include path, your CCfits installation should
+  #have included a pkg-config file and mentioned it, or you should have dropped in your
+  #own find module here. Good luck.
+  add_library(CCfits IMPORTED)
+  set_target_properties(CCfits IMPORTED_LOCATION ${CCFITS_LIB})
+  
+endif()

--- a/cmake/FindCCfits.cmake
+++ b/cmake/FindCCfits.cmake
@@ -21,7 +21,7 @@ else()
   #If you have a non-standard include path, your CCfits installation should
   #have included a pkg-config file and mentioned it, or you should have dropped in your
   #own find module here. Good luck.
-  add_library(CCfits IMPORTED)
+  add_library(CCfits UNKNOWN IMPORTED)
   set_target_properties(CCfits IMPORTED_LOCATION ${CCFITS_LIB})
   
 endif()

--- a/cmake/FindCCfits.cmake
+++ b/cmake/FindCCfits.cmake
@@ -22,6 +22,6 @@ else()
   #have included a pkg-config file and mentioned it, or you should have dropped in your
   #own find module here. Good luck.
   add_library(CCfits UNKNOWN IMPORTED)
-  set_target_properties(CCfits IMPORTED_LOCATION ${CCFITS_LIB})
+  set_target_properties(CCfits PROPERTIES IMPORTED_LOCATION ${CCFITS_LIB})
   
 endif()

--- a/cmake/FindCCfits.cmake~
+++ b/cmake/FindCCfits.cmake~
@@ -1,0 +1,4 @@
+#CCfits does by default provide a pkg-config recipe. Try this first, it's likely the best
+#however may not work on mac or windows
+
+find_package(PkgConfig QUIET)

--- a/cmake/Findcfitsio.cmake
+++ b/cmake/Findcfitsio.cmake
@@ -1,0 +1,37 @@
+#cfitsio *sometimes* includes a CMake config file. This is the worst of all possible worlds.
+#On systems where it doesn't, it will fall back to this find module
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  message(VERBOSE "found pkg-config, trying to locate cfitsio using it")
+  pkg_check_modules(cfitsio cfitsio REQUIRED IMPORTED_TARGET)
+
+  add_library(cfitsio ALIAS PkgConfig::cfitsio)
+
+  get_target_property(PROP cfitsio INTERFACE_INCLUDE_DIRECTORIES)
+  message(VERBOSE "iid: ${PROP}")
+  message(VERBOSE "id: ${cfitsio_INCLUDE_DIRS}")
+
+
+  
+else()
+    message(VERBOSE "no pkg-config, trying to locate cfitsio manually")
+    find_library(CFITS_LIB cfitsio NAMES libcfitsio PATHS /usr/local/lib)
+    add_library(cfitsio UNKNOWN IMPORTED)
+    set_target_properties(cfitsio PROPERTIES IMPORTED_LOCATION ${CFITS_LIB})
+
+    find_path(FITSIO_INCLUDE fitsio.h)
+
+    message(VERBOSE "fitsio.h include location: ${FITSIO_INCLUDE}")
+
+    if(NOT FITSIO_INCLUDE)
+      message(FATAL_ERROR "could not find fitsio.h file, build cannot continue!")
+    endif()
+     
+    get_filename_component(CFITSIO_INCLUDE_DIR ${FITSIO_INCLUDE} DIRECTORY)
+
+    set_target_properties(cfitsio PROPERTIES INTERFACE_INCLUDE_DIRECTORIES ${CFITSIO_INCLUDE_DIR})
+    
+    set(cfitsio_FOUND TRUE)
+  
+endif()

--- a/cmake/Findcfitsio.cmake~
+++ b/cmake/Findcfitsio.cmake~
@@ -1,0 +1,2 @@
+#cfitsio *sometimes* includes a CMake config file. This is the worst of all possible worlds.
+#On systems where it doesn't, it will fall back to this find module

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -10,9 +10,9 @@ set(PROJECT_UTILS_DIR ${PROJECT_BASE_DIR}/common)
 
 add_definitions(-Wall -ansi -O2 -Wno-variadic-macros -std=c++17 -ggdb)
 
-include_directories(${PROJECT_BASE_DIR}/common)
-include_directories(${PROJECT_BASE_DIR}/utils)    # needed for logentry
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+include_directories(${CMAKE_SOURCE_DIR}/utils)    # needed for logentry
 
 add_library(common STATIC
-        ${PROJECT_UTILS_DIR}/common.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/common.cpp
 )

--- a/common/CMakeLists.txt
+++ b/common/CMakeLists.txt
@@ -6,13 +6,12 @@
 
 cmake_minimum_required(VERSION 3.12)
 
-set(PROJECT_UTILS_DIR ${PROJECT_BASE_DIR}/common)
+add_definitions(-Wall -Wno-variadic-macros)
 
-add_definitions(-Wall -ansi -O2 -Wno-variadic-macros -std=c++17 -ggdb)
-
-include_directories(${CMAKE_CURRENT_SOURCE_DIR})
+#for now have hard coded path here, better in future
+#to add include directory as a link interface property
+#of a preceeding target. But that may not be available in
+#cmake 3.12
 include_directories(${CMAKE_SOURCE_DIR}/utils)    # needed for logentry
 
-add_library(common STATIC
-        ${CMAKE_CURRENT_SOURCE_DIR}/common.cpp
-)
+add_library(common  common.cpp)

--- a/emulator/CMakeLists.txt
+++ b/emulator/CMakeLists.txt
@@ -3,10 +3,7 @@
 # ----------------------------------------------------------------------------
 
 cmake_minimum_required( VERSION 3.12 )
-
-set( EMULATOR_DIR ${PROJECT_BASE_DIR}/emulator )
-
-add_definitions( -Wall -ansi -O1 -Wno-variadic-macros -std=c++17 -ggdb )
+add_definitions( -Wall -Wno-variadic-macros)
 
 include_directories( ${CMAKE_SOURCE_DIR}/utils 
                      ${CMAKE_SOURCE_DIR}/camerad 
@@ -26,8 +23,7 @@ add_library(${EMULATOR_TARGET} ${EMULATOR_SOURCE})
 
 target_include_directories(${EMULATOR_TARGET} PUBLIC ${PROJECT_INCL_DIR})
 
-add_executable(emulator
-        emulator-server.cpp
+add_executable(emulator emulator-server.cpp
         )
 
 target_link_libraries(emulator

--- a/emulator/CMakeLists.txt
+++ b/emulator/CMakeLists.txt
@@ -8,18 +8,18 @@ set( EMULATOR_DIR ${PROJECT_BASE_DIR}/emulator )
 
 add_definitions( -Wall -ansi -O1 -Wno-variadic-macros -std=c++17 -ggdb )
 
-include_directories( ${PROJECT_BASE_DIR}/utils 
-                     ${PROJECT_BASE_DIR}/camerad 
-                     ${PROJECT_BASE_DIR}/common )
+include_directories( ${CMAKE_SOURCE_DIR}/utils 
+                     ${CMAKE_SOURCE_DIR}/camerad 
+                     ${CMAKE_SOURCE_DIR}/common )
 
 if( ${INTERFACE_TYPE} STREQUAL "Archon" )
         add_definitions(-DSTA_ARCHON)
         set( EMULATOR_TARGET emulatorArchon )
         list(APPEND EMULATOR_SOURCE
-                "${EMULATOR_DIR}/emulator-archon.cpp"
+                "emulator-archon.cpp"
                 )
         add_library(emulatorInterface STATIC
-                ${EMULATOR_DIR}/emulator-archon.cpp
+                emulator-archon.cpp
                 )
 
 add_library(${EMULATOR_TARGET} ${EMULATOR_SOURCE})
@@ -27,7 +27,7 @@ add_library(${EMULATOR_TARGET} ${EMULATOR_SOURCE})
 target_include_directories(${EMULATOR_TARGET} PUBLIC ${PROJECT_INCL_DIR})
 
 add_executable(emulator
-        ${EMULATOR_DIR}/emulator-server.cpp
+        emulator-server.cpp
         )
 
 target_link_libraries(emulator

--- a/emulator/CMakeLists.txt
+++ b/emulator/CMakeLists.txt
@@ -5,6 +5,7 @@
 cmake_minimum_required( VERSION 3.12 )
 add_definitions( -Wall -Wno-variadic-macros)
 
+
 include_directories( ${CMAKE_SOURCE_DIR}/utils 
                      ${CMAKE_SOURCE_DIR}/camerad 
                      ${CMAKE_SOURCE_DIR}/common )
@@ -20,8 +21,8 @@ if( ${INTERFACE_TYPE} STREQUAL "Archon" )
                 )
 
 add_library(${EMULATOR_TARGET} ${EMULATOR_SOURCE})
-
-target_include_directories(${EMULATOR_TARGET} PUBLIC ${PROJECT_INCL_DIR})
+target_link_libraries(${EMULATOR_TARGET} PUBLIC cfitsio CCfits)
+target_link_libraries(emulatorInterface PUBLIC cfitsio CCfits)
 
 add_executable(emulator emulator-server.cpp
         )

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -1,34 +1,20 @@
 # ----------------------------------------------------------------------------
 # utils/CMakeLists.txt
 # ----------------------------------------------------------------------------
-cmake_minimum_required(VERSION 3.12)
+#cmake_minimum_required(VERSION 3.12)
 
-#set(PROJECT_UTILS_DIR ${PROJECT_BASE_DIR}/utils)
+add_definitions(-Wall -Wno-variadic-macros)
 
-add_definitions(-Wall -ansi -O1 -Wno-variadic-macros -std=c++17 -ggdb)
+add_library(utilities utilities.cpp md5)
 
-add_library(utilities STATIC
-        utilities.cpp
-        md5
-)
+add_library(logentry  logentry.cpp)
 
-add_library(logentry STATIC
-        logentry.cpp
-)
 target_link_libraries(logentry $<IF:$<PLATFORM_ID:Darwin>,,stdc++fs>)
 
-add_library(network STATIC
-        network.cpp
-)
+add_library(network STATIC network.cpp)
 
-add_library(md5 STATIC
-        md5.cpp
-)
+add_library(md5 STATIC md5.cpp)
 
-add_executable(listener
-        listener.cpp
-)
+add_executable(listener listener.cpp)
 
-add_executable(socksend
-        sendcmd.cpp
-)
+add_executable(socksend  sendcmd.cpp)

--- a/utils/CMakeLists.txt
+++ b/utils/CMakeLists.txt
@@ -3,32 +3,32 @@
 # ----------------------------------------------------------------------------
 cmake_minimum_required(VERSION 3.12)
 
-set(PROJECT_UTILS_DIR ${PROJECT_BASE_DIR}/utils)
+#set(PROJECT_UTILS_DIR ${PROJECT_BASE_DIR}/utils)
 
 add_definitions(-Wall -ansi -O1 -Wno-variadic-macros -std=c++17 -ggdb)
 
 add_library(utilities STATIC
-        ${PROJECT_UTILS_DIR}/utilities.cpp
+        utilities.cpp
         md5
 )
 
 add_library(logentry STATIC
-        ${PROJECT_UTILS_DIR}/logentry.cpp
+        logentry.cpp
 )
 target_link_libraries(logentry $<IF:$<PLATFORM_ID:Darwin>,,stdc++fs>)
 
 add_library(network STATIC
-        ${PROJECT_UTILS_DIR}/network.cpp
+        network.cpp
 )
 
 add_library(md5 STATIC
-        ${PROJECT_UTILS_DIR}/md5.cpp
+        md5.cpp
 )
 
 add_executable(listener
-        ${PROJECT_UTILS_DIR}/listener.cpp
+        listener.cpp
 )
 
 add_executable(socksend
-        ${PROJECT_UTILS_DIR}/sendcmd.cpp
+        sendcmd.cpp
 )


### PR DESCRIPTION
This patch is intended to start modernising the CMake build system, just a little bit. If there is acceptance of these type of things I'll go further in future because modernising CMake build systems is a weird hobby of mine.

The reasons are:
   - use of absolute paths based on environment variables is pretty annoying (when e.g. wanting to build with docker)
   - the current system utterly fails if your cfitsio and ccfits are not installed in specific locations (this is true e.g. for fedora and suse based distributions)
   - it does not currently support "true" out of source builds (i.e. it always dumps libraries and binaries in the source dir anyway), and because of environment variable computation required running from the "./build" directory, again quite annoying to write a consistent docker /container file for
   - there is unnecessary definition of manual compiler flags which is taken care of by CMake if using their features as documented

Nothing here should break any existing buyild instructions. I have tried out those instructions in an ubuntu 22.04 distrobox and it still appears to work. But please let me know if anything looks concerning. I would like to have this merged so I can work on a reasonably simple Docker build process. Currently t hat build process would be highly compillicated.